### PR TITLE
New helper templateIs to allow dynamic classes based on template name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var autoprefixer = require('gulp-autoprefixer');
 var concat = require('gulp-concat');
 var clean = require('gulp-clean');
+const hb = require('gulp-hb');
 
 
 // Development Tasks
@@ -50,13 +51,18 @@ gulp.task('sass', function () {
 });
 
 gulp.task('handlebars', function () {
-    let data = JSON.parse(fs.readFileSync('src/data.json'));
-    let options = {
-        ignorePartials: true, // ignores any unknown partials. Useful if you only want to handle part of the file
-        batch : ['src/partials'] // Javascript array of filepaths to use as partials   <--- where your partials go
-    };
     return gulp.src('src/templates/**/*.hbs')
-        .pipe(handlebars(data, options))
+        .pipe(hb()
+            .partials('src/partials/**/*.hbs')
+            .helpers({
+                templateName: function (item) {
+                    return item.path.substring(item.base.length);
+                },
+                templateIs: function (item, templateName, className) {
+                    return item.path.substring(item.base.length) === templateName ? className : "";
+                }
+            })
+        )
         .pipe(rename(function(path) {
             path.extname = '.html';
         }))

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-clean": "^0.4.0",
     "gulp-compile-handlebars": "^0.6.1",
     "gulp-concat": "^2.6.1",
+    "gulp-hb": "^8.0.0",
     "gulp-rename": "^1.4.0"
   }
 }

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -7,6 +7,18 @@
 
             <p>this file is src/templates/index.hbs</p>
 
+            <div>@file.base: {{ @file.base }}</div>
+            <div>templateName helper output: {{ templateName @file }}</div>
+
+            <div>
+                Checking template is called "unknown.hbs": {{ templateIs @file "unknown.hbs" "active" }}
+            </div>
+            <div>
+                Checking template is called "index.hbs": {{ templateIs @file "index.hbs" "active" }}
+
+                This element should have an "active" class on it  <div style="background-color: red" class="{{ templateIs @file "index.hbs" "active" }}">Here</div>
+            </div>
+
             <p>Visit the <a class="button" href="/about.html">About page</a> </p>
         </div>
 


### PR DESCRIPTION
Ditches the first handlebars plugin for `gulp-hb` which gives more useful information like the file name. Docs https://www.npmjs.com/package/gulp-hb

Added a custom helpers to get the template file name.

Also added a custom helper to return a classname if the current file template is a specific name:

    {{ templateIs @file "index.hbs" "active" }}

returns "active" if the current template is `index.hbs`. Returns nothing otherwise. 

This can be added to a 

    <div class="  {{ templateIs @file "index.hbs" "active" }}   "> 

To show the active link in a nav.